### PR TITLE
Removed invalid key 'report_per_cpu' in Splunk HEC example

### DIFF
--- a/exporter/splunkhecexporter/example/otel-collector-config.yml
+++ b/exporter/splunkhecexporter/example/otel-collector-config.yml
@@ -3,7 +3,6 @@ receivers:
     collection_interval: 5s
     scrapers:
       cpu:
-        report_per_cpu: true
       disk:
       load:
       filesystem:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
CPU scraper `report_per_cpu` was removed in [version 0.6](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md#v060-beta), so removing the flag to avoid a fatal error when running the Splunk HEC example.

**Link to tracking Issue:**
N/A

**Testing:**
Removed the option and ran the example again, this time successful.

**Documentation:**
N/A